### PR TITLE
Reset RSSI packet-miss count after reporting it.

### DIFF
--- a/RC_RX_CABELL_V3_FHSS.ino
+++ b/RC_RX_CABELL_V3_FHSS.ino
@@ -39,8 +39,15 @@
 #include "Pins.h"
 
 //--------------------------------------------------------------------------------------------------------------------------
+// which sketch is running?
+void showID(void) {
+  Serial.println(F("Running " __FILE__ "\nBuilt " __DATE__));
+}
+
+//--------------------------------------------------------------------------------------------------------------------------
 void setup(void) {
   Serial.begin(74880);
+  showID();
   Serial.println(); Serial.println(F("Initializing"));
   
   pinMode (BIND_BUTTON_PIN,INPUT_PULLUP);  // used for bind plug or button

--- a/RSSI.cpp
+++ b/RSSI.cpp
@@ -84,6 +84,10 @@ void RSSI::resetCounters() {
 
 //--------------------------------------------------------------------------------------------------------------------------
 uint8_t RSSI::getRSSI() {
- return constrain(packetRate - sequentialMissTrack,TELEMETRY_RSSI_MIN_VALUE,TELEMETRY_RSSI_MAX_VALUE);
+  uint8_t rssi =
+     constrain(packetRate - sequentialMissTrack,TELEMETRY_RSSI_MIN_VALUE,TELEMETRY_RSSI_MAX_VALUE);
+  // clear tracking count for next time; no double-counting
+  // It is not part of resetCounters() to return a more recent/timely value to transmitter
+  sequentialMissTrack = TELEMETRY_RSSI_MIN_VALUE;
+  return rssi;
 }
-


### PR DESCRIPTION
Keeps previous misses from masking recent signal improvements.